### PR TITLE
Add MIT License to the project

### DIFF
--- a/LICENSE.MD
+++ b/LICENSE.MD
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 emailscript contributors
+Copyright (c) 2025 pankaj kumar bind
 
 Permission is hereby granted, free of charge, to any person obtaining a copy  
 of this software and associated documentation files (the "Software"), to deal  

--- a/LICENSE.MD
+++ b/LICENSE.MD
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 emailscript contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy  
+of this software and associated documentation files (the "Software"), to deal  
+in the Software without restriction, including without limitation the rights  
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell  
+copies of the Software, and to permit persons to whom the Software is  
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in  
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,  
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE  
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER  
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  
+SOFTWARE


### PR DESCRIPTION
This PR adds an MIT License file to the project.
Since the project doesn't currently have a license, I’ve added the standard MIT License and credited it to "emailscript contributors" as the copyright holder.
 If the project has a specific owner, please let me know and I’ll be happy to update the license with their name.
Let me know if any changes are needed. Thank you